### PR TITLE
add usage field to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An experimental, highly opinionated OpenAI API wrapper for Rust. This is primari
 
 use kind_openai::{
     endpoints::chat::{ChatCompletionModel, ChatCompletionRequest, ChatCompletionRequestMessage},
-    EnvironmentAuthTokenProvider, OpenAI, OpenAISchema,
+    system_message, user_message, EnvironmentAuthTokenProvider, OpenAI, OpenAISchema,
 };
 use serde::Deserialize;
 
@@ -23,14 +23,14 @@ pub struct Name {
 async fn main() {
     let client = OpenAI::new(EnvironmentAuthTokenProvider);
 
+    let name = "John Doe";
+
     let chat_completion: ChatCompletionRequest<Name> =
         ChatCompletionRequest::new_structured(ChatCompletionModel::Gpt4oMini)
-            .message(ChatCompletionRequestMessage::system(
-                "Extract the first and last name from the provided message.",
+            .message(system_message!(
+                "Extract the first and last name from the provided message."
             ))
-            .message(ChatCompletionRequestMessage::user(
-                "Hello, my name is John Doe.",
-            ))
+            .message(user_message!("Hello, my name is {name}."))
             .temperature(0.1);
 
     let name = client

--- a/crates/kind-openai/Cargo.toml
+++ b/crates/kind-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kind-openai"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Highly opinionated OpenAI API wrapper crate. By Kindness Inc."
 license = "MIT"

--- a/crates/kind-openai/src/endpoints/chat.rs
+++ b/crates/kind-openai/src/endpoints/chat.rs
@@ -181,7 +181,7 @@ impl<T> ChatCompletion<T> {
         }
     }
 
-    pub fn get_usage(&self) -> &Usage {
+    pub fn usage(&self) -> &Usage {
         &self.usage
     }
 }

--- a/crates/kind-openai/src/endpoints/chat.rs
+++ b/crates/kind-openai/src/endpoints/chat.rs
@@ -11,7 +11,7 @@ use super::API_BASE_URL;
 use crate::{
     auth,
     error::{OpenAIAPIError, OpenAIResponseExt, OpenAIResult},
-    util, OpenAI, OpenAIError,
+    util, OpenAI, OpenAIError, Usage,
 };
 
 #[derive(Serialize, Clone, Copy)]
@@ -204,13 +204,6 @@ impl<T> ChatCompletionChoice<T> {
 struct ChatCompletionResponseMessage<T> {
     content: T,
     refusal: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct Usage {
-    pub prompt_tokens: u32,
-    pub completion_tokens: u32,
-    pub total_tokens: u32,
 }
 
 // `content` is a string that contains json inside of it, but we want to unravel

--- a/crates/kind-openai/src/lib.rs
+++ b/crates/kind-openai/src/lib.rs
@@ -13,6 +13,7 @@ use endpoints::chat::ChatCompletion;
 pub use error::{OpenAIError, OpenAIResult};
 pub use kind_openai_schema::*;
 use reqwest::{IntoUrl, Method};
+use serde::Deserialize;
 pub use util::UnstructuredString;
 
 /// A handle to OpenAI.
@@ -90,4 +91,11 @@ where
     ) -> OpenAIResult<endpoints::embeddings::CreateEmbeddingsResponse> {
         endpoints::embeddings::create_embeddings(self, req).await
     }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
 }


### PR DESCRIPTION
It would be nice to have usage in the response from OAI. 

https://platform.openai.com/docs/guides/structured-outputs/refusals
