### PR TITLE
add invalid request error

### DIFF
--- a/crates/kind-openai/Cargo.toml
+++ b/crates/kind-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kind-openai"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "Highly opinionated OpenAI API wrapper crate. By Kindness Inc."
 license = "MIT"

--- a/crates/kind-openai/src/error.rs
+++ b/crates/kind-openai/src/error.rs
@@ -46,6 +46,8 @@ pub enum OpenAIAPIError {
     QuotaExceeded(OpenAIAPIErrorData),
     #[error("internal error")]
     InternalError(OpenAIAPIErrorData),
+    #[error("invalid request error")]
+    InvalidRequestError(OpenAIAPIErrorData),
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
This error handles the case when the request fails because the context is too large. 

For example, now our error ends up being: 

`API(InvalidRequestError(OpenAIAPIErrorData { message: "Invalid 'messages[1].content': string too long. Expected a string with maximum length 1048576, but got a string with length 1114138 instead.", param: Some("messages[1].content"), code: Some("string_above_max_length") }))`

