### PR TITLE
add logit bias, macro, update example

### DIFF
--- a/crates/kind-openai/Cargo.toml
+++ b/crates/kind-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kind-openai"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "Highly opinionated OpenAI API wrapper crate. By Kindness Inc."
 license = "MIT"

--- a/crates/kind-openai/examples/basic.rs
+++ b/crates/kind-openai/examples/basic.rs
@@ -2,7 +2,7 @@
 
 use kind_openai::{
     endpoints::chat::{ChatCompletion, Model},
-    system_message, user_message, EnvironmentAuthTokenProvider, OpenAI, OpenAISchema,
+    logit_bias, system_message, user_message, EnvironmentAuthTokenProvider, OpenAI, OpenAISchema,
 };
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
@@ -53,7 +53,10 @@ pub enum Category {
 async fn main() {
     let client = OpenAI::new(EnvironmentAuthTokenProvider);
 
-    let name = "John";
+    let name = "John but sometimes people call me Jonathan";
+
+    // do not return Jonathan
+    let logit_bias = logit_bias!(128395: -100);
 
     let chat_completion = ChatCompletion::model(Model::Gpt4oMini)
         .messages(vec![
@@ -61,6 +64,7 @@ async fn main() {
             user_message!("Hello, my name is {name}."),
         ])
         .temperature(0.1)
+        .logit_bias(logit_bias)
         .structured::<Name>();
 
     let name = client

--- a/crates/kind-openai/src/endpoints/chat/standard.rs
+++ b/crates/kind-openai/src/endpoints/chat/standard.rs
@@ -25,6 +25,7 @@ pub struct ChatCompletion<'a> {
     top_p: Option<f32>,
     store: Option<bool>,
     metadata: Option<HashMap<String, String>>,
+    logit_bias: Option<HashMap<i32, i32>>,
 }
 
 impl OpenAIRequestProvider for ChatCompletion<'_> {
@@ -119,4 +120,19 @@ impl From<ChatCompletionResponseMessage> for UnifiedChatCompletionResponseMessag
             refusal: value.refusal,
         }
     }
+}
+
+#[macro_export]
+macro_rules! logit_bias {
+    () => {
+        std::collections::HashMap::new()
+    };
+
+    ($($key:tt : $value:expr),+ $(,)?) => {{
+        let mut map = std::collections::HashMap::new();
+        $(
+            map.insert($key as i32, $value as i32);
+        )+
+        map
+    }};
 }


### PR DESCRIPTION
Adds [logit_bias](https://platform.openai.com/docs/api-reference/completions/create#completions-create-logit_bias) 

[Using logit bias to alter token probability with the OpenAI API](https://help.openai.com/en/articles/5247780-using-logit-bias-to-alter-token-probability-with-the-openai-api)